### PR TITLE
+closed_shell,+surface_curve

### DIFF
--- a/src/IxMilia.Step/Items/StepClosedShell.cs
+++ b/src/IxMilia.Step/Items/StepClosedShell.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using IxMilia.Step.Syntax;
+
+namespace IxMilia.Step.Items
+{
+    public class StepClosedShell : StepTopologicalRepresentationItem
+    {
+        public List<StepAdvancedFace> Faces { get; } = new List<StepAdvancedFace>();
+
+        public StepClosedShell(string name)
+            : base(name)
+        {
+        }
+
+        private StepClosedShell()
+            : base(string.Empty)
+        {
+        }
+
+        public override StepItemType ItemType => StepItemType.ClosedShell;
+
+        internal static StepClosedShell CreateFromSyntaxList(StepBinder binder, StepSyntaxList syntaxList)
+        {
+            var shell = new StepClosedShell();
+            
+            shell.Name = syntaxList.Values[0].GetStringValue();
+
+            var boundsList = syntaxList.Values[1].GetValueList();
+            shell.Faces.Clear();
+            shell.Faces.AddRange(Enumerable.Range(0, boundsList.Values.Count).Select(_ => (StepAdvancedFace)null));
+            for (int i = 0; i < boundsList.Values.Count; i++)
+            {
+                var j = i; // capture to avoid rebinding
+                binder.BindValue(boundsList.Values[j], v => shell.Faces[j] = v.AsType<StepAdvancedFace>());
+            }            
+
+            return shell;
+        }
+    }
+}

--- a/src/IxMilia.Step/Items/StepItemType.cs
+++ b/src/IxMilia.Step/Items/StepItemType.cs
@@ -4,6 +4,7 @@ namespace IxMilia.Step.Items
 {
     public enum StepItemType
     {
+        ClosedShell,
         AdvancedFace,
         AxisPlacement2D,
         AxisPlacement3D,
@@ -13,6 +14,7 @@ namespace IxMilia.Step.Items
         CylindricalSurface,
         Direction,
         EdgeCurve,
+        SurfaceCurve,
         EdgeLoop,
         Ellipse,
         FaceBound,
@@ -26,6 +28,7 @@ namespace IxMilia.Step.Items
 
     internal static class StepItemTypeExtensions
     {
+        public const string ClosedShellText = "CLOSED_SHELL";
         public const string AdvancedFaceText = "ADVANCED_FACE";
         public const string Axis2Placement2DText = "AXIS2_PLACEMENT_2D";
         public const string Axis2Placement3DText = "AXIS2_PLACEMENT_3D";
@@ -33,8 +36,9 @@ namespace IxMilia.Step.Items
         public const string CartesianPointText = "CARTESIAN_POINT";
         public const string CircleText = "CIRCLE";
         public const string CylindricalSurfaceText = "CYLINDRICAL_SURFACE";
-        public const string DirectionText = "DIRECTION";
+        public const string DirectionText = "DIRECTION";        
         public const string EdgeCurveText = "EDGE_CURVE";
+        public const string SurfaceCurveText = "SURFACE_CURVE";
         public const string EdgeLoopText = "EDGE_LOOP";
         public const string EllipseText = "ELLIPSE";
         public const string FaceBoundText = "FACE_BOUND";
@@ -49,6 +53,8 @@ namespace IxMilia.Step.Items
         {
             switch (type)
             {
+                case StepItemType.ClosedShell:
+                    return ClosedShellText;
                 case StepItemType.AdvancedFace:
                     return AdvancedFaceText;
                 case StepItemType.AxisPlacement2D:
@@ -66,6 +72,8 @@ namespace IxMilia.Step.Items
                 case StepItemType.Direction:
                     return DirectionText;
                 case StepItemType.EdgeCurve:
+                    return SurfaceCurveText;
+                case StepItemType.SurfaceCurve:
                     return EdgeCurveText;
                 case StepItemType.EdgeLoop:
                     return EdgeLoopText;

--- a/src/IxMilia.Step/Items/StepRepresentationItem_FromTypedParameter.cs
+++ b/src/IxMilia.Step/Items/StepRepresentationItem_FromTypedParameter.cs
@@ -16,6 +16,9 @@ namespace IxMilia.Step.Items
                 var simpleItem = (StepSimpleItemSyntax)itemSyntax;
                 switch (simpleItem.Keyword)
                 {
+                    case StepItemTypeExtensions.ClosedShellText:
+                        item = StepClosedShell.CreateFromSyntaxList(binder, simpleItem.Parameters);
+                        break;
                     case StepItemTypeExtensions.AdvancedFaceText:
                         item = StepAdvancedFace.CreateFromSyntaxList(binder, simpleItem.Parameters);
                         break;
@@ -42,6 +45,9 @@ namespace IxMilia.Step.Items
                         break;
                     case StepItemTypeExtensions.EdgeCurveText:
                         item = StepEdgeCurve.CreateFromSyntaxList(binder, simpleItem.Parameters);
+                        break;
+                    case StepItemTypeExtensions.SurfaceCurveText:
+                        item = StepSurfaceCurve.CreateFromSyntaxList(binder, simpleItem.Parameters);
                         break;
                     case StepItemTypeExtensions.EdgeLoopText:
                         item = StepEdgeLoop.CreateFromSyntaxList(binder, simpleItem.Parameters);

--- a/src/IxMilia.Step/Items/StepSurfaceCurve.cs
+++ b/src/IxMilia.Step/Items/StepSurfaceCurve.cs
@@ -1,0 +1,31 @@
+﻿using IxMilia.Step.Syntax;
+
+namespace IxMilia.Step.Items
+{
+    public class StepSurfaceCurve : StepCurve
+    {
+        private StepSurfaceCurve(string name)
+            : base(name)
+        {
+        }
+
+        private StepSurfaceCurve()
+        : base(string.Empty)
+        {
+        }
+
+        public StepCurve Geometry;
+
+        public override StepItemType ItemType => StepItemType.SurfaceCurve;
+
+        internal static StepSurfaceCurve CreateFromSyntaxList(StepBinder binder, StepSyntaxList syntaxList)
+        {            
+            var curve = new StepSurfaceCurve();       
+            curve.Name = syntaxList.Values[0].GetStringValue();
+
+            binder.BindValue(syntaxList.Values[1], v => curve.Geometry = v.AsType<StepCurve>());
+            
+            return curve;
+        }
+    }
+}


### PR DESCRIPTION
Allows to iterate through all shells->faces->wires->edges as follows:

            StepFile stepFile;
            using (FileStream fs = new FileStream(@"tube1.step", FileMode.Open))
            {
                stepFile = StepFile.Load(fs);
            }

            foreach (StepRepresentationItem item in stepFile.Items)
            {
                switch (item.ItemType)
                {
                    case StepItemType.ClosedShell:
                        var shell = (StepClosedShell)item;
                        Console.WriteLine($"shell : {shell.Name}");
                        foreach (var face in shell.Faces)
                        {
                            Console.WriteLine($"face : {face.Name} {face.FaceGeometry.ItemType}");
                            
                            foreach (var wire in face.Bounds)
                            {
                                Console.WriteLine($"wire: {wire.Name}");
                                foreach (var edge in ((StepEdgeLoop)wire.Bound).EdgeList)
                                {
                                    var start = ((StepVertexPoint)edge.EdgeElement.EdgeStart).Location;
                                    var end = ((StepVertexPoint)edge.EdgeElement.EdgeEnd).Location;
                                    Console.WriteLine($"start: {start.X};{start.Y};{start.Z}   end: {end.X};{end.Y};{end.Z}");
                                }
                            }
                        }                        
                        break;                        
                }
            }